### PR TITLE
Deploy to build only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ cache:
 script:
 - yarn build
 after_success:
-- test $TRAVIS_BRANCH = "master" && yarn run deploy:travis -- --branch=build
+- test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && yarn run deploy:travis -- --branch=build


### PR DESCRIPTION
And not for each PR during the "merge" build.
It avoids unwanted commit in the build branch.