### PR TITLE
fix: add file path to standalone script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "node ./src/index.js",
     "dev": "cozy-konnector-dev",
-    "standalone": "cozy-konnector-standalone",
+    "standalone": "cozy-konnector-standalone src/index",
     "build": "webpack",
     "format": "prettier --write '**/*.{js,json}'",
     "precommit": "yarn lint",


### PR DESCRIPTION
While trying to follow [the documentation](https://docs.cozy.io/fr/dev/konnector/#cozy-konnector-template-and-standalone-mode) I got an error when I executed the standalone script : 

```
Error: Cannot find module '/home/drazik/workspace/cozy/cozy-konnector-template/index.js'
```

I fixed it by providing the `src/index.js` path to the script.