### PR TITLE
feat: remove direct dependency to prettier and format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
     "dev": "cozy-konnector-dev src/index",
     "standalone": "cozy-konnector-standalone src/index",
     "build": "webpack",
-    "format": "prettier --write '**/*.{js,json}'",
     "precommit": "yarn lint",
-    "lint": "eslint .",
+    "lint": "eslint --fix .",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/konnectors/cozy-konnector-template.git}"
   },
   "dependencies": {
@@ -42,7 +41,6 @@
     "eslint-config-cozy-app": "0.5.1",
     "git-directory-deploy": "1.5.1",
     "husky": "0.14.3",
-    "prettier": "1.11.1",
     "webpack": "4.2.0",
     "webpack-cli": "2.0.13"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5938,7 +5938,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.11.1, prettier@^1.11.1, prettier@^1.5.3:
+prettier@^1.11.1, prettier@^1.5.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 


### PR DESCRIPTION
Since we now use eslint-config-cozy-app@0.5.x and prettier is built in, we don't need the direct dependency to prettier and the format script anymore.