### PR TITLE
fix: manifest typos + now deploy stable version on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,17 @@ script:
   - yarn lint
   - yarn build
 deploy:
+  # publish dev versions
   - provider: script
     repo: konnectors/cozy-konnector-template
     skip-cleanup: true
     script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
     on:
       branch: master
+  # publish stable versions and beta versions based on tags
   - provider: script
     repo: konnectors/cozy-konnector-template
     skip-cleanup: true
-    script: DEPLOY_BRANCH=latest && yarn deploy && yarn cozyPublish
+    script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
     on:
-      branch: prod
+      tags: true

--- a/manifest.konnector
+++ b/manifest.konnector
@@ -4,10 +4,10 @@
   "type": "konnector",
   "language": "node",
   "icon": "icon.png",
-  "slug": "template-collect",
+  "slug": "template",
   "source": "git://github.com/konnectors/cozy-konnector-template.git",
   "editor": "Cozy",
-  "vendorLink": "Link to the target website",
+  "vendor_link": "Link to the target website",
   "categories": ["other"],
   "fields": {
     "advancedFields": {
@@ -17,7 +17,7 @@
       }
     }
   },
-  "dataType": [
+  "data_types": [
     "bill"
   ],
   "screenshots": [ "screenshots/screenshot1.png" ],


### PR DESCRIPTION
I hope this is the last change concerning registry deployment : 

- no `-collect` prefix
- there is no need for `prod` and `latest` branches now
- manifest attributes use snake case
- a commit on master deploys a dev version on the registry
- a commit with a tag deploys a stable version on the registry