### PR TITLE
feat: new template which is supposed to be more representative of a real connector

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -10,6 +10,12 @@
   "vendor_link": "Link to the target website",
   "categories": ["other"],
   "fields": {
+    "login": {
+      "type": "text"
+    },
+    "password": {
+      "type": "password"
+    },
     "advancedFields": {
       "folderPath": {
         "advanced": true,
@@ -22,8 +28,11 @@
   ],
   "screenshots": [ "screenshots/screenshot1.png" ],
   "permissions": {
-    "books": {
-      "type": "io.cozy.books"
+    "bank operations": {
+      "type": "io.cozy.bank.operations"
+    },
+    "bills": {
+      "type": "io.cozy.bills"
     },
     "files": {
       "type": "io.cozy.files"
@@ -43,8 +52,11 @@
       "short_description": "Template de connecteur",
       "long_description": "Ce template récupère une liste de livres sur un site de scraping",
       "permissions": {
-        "books": {
-          "description": "Utilisé pour sauvegarder les références des livres"
+        "bank operations": {
+          "description": "Utilisé pour relier les factures à des operations bancaires"
+        },
+        "bills": {
+          "description": "Utilisé pour sauver les données des factures"
         },
         "files": {
           "description": "Utilisé pour sauvegarder les factures"
@@ -58,8 +70,11 @@
       "short_description": "Connector template",
       "long_description": "This template fetches a list of books from a scraping website",
       "permissions": {
-        "books": {
-          "description": "Required to save books references"
+        "bank operations": {
+          "description": "Required to link bank operations to bills"
+        },
+        "bills": {
+          "description": "Required to save the bills data"
         },
         "files": {
           "description": "Required to save the bills"

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,23 @@
 const {
   BaseKonnector,
   requestFactory,
-  saveFiles,
-  addData
+  signin,
+  scrape,
+  saveBills,
+  log
 } = require('cozy-konnector-libs')
-const request = requestFactory({ cheerio: true })
+const request = requestFactory({
+  // the debug mode shows all the details about http request and responses. Very usefull for
+  // debugging but very verbose. That is why it is commented out by default
+  // debug: true,
+  // activates [cheerio](https://cheerio.js.org/) parsing on each page
+  cheerio: true,
+  // If cheerio is activated do not forget to deactivate json parsing (which is activated by
+  // default in cozy-konnector-libs
+  json: false,
+  // this allows request-promise to keep cookies between requests
+  jar: true
+})
 
 const baseUrl = 'http://books.toscrape.com'
 
@@ -13,34 +26,94 @@ module.exports = new BaseKonnector(start)
 // The start function is run by the BaseKonnector instance only when it got all the account
 // information (fields). When you run this connector yourself in "standalone" mode or "dev" mode,
 // the account information come from ./konnector-dev-config.json file
-function start(fields) {
+async function start(fields) {
+  await authenticate(fields.login, fields.password)
   // The BaseKonnector instance expects a Promise as return of the function
-  return request(`${baseUrl}/index.html`).then($ => {
-    // cheerio (https://cheerio.js.org/) uses the same api as jQuery (http://jquery.com/)
-    // here I do an Array.from to convert the cheerio fake array to a real js array.
-    const entries = Array.from($('article')).map(article =>
-      parseArticle($, article)
-    )
-    return addData(entries, 'io.cozy.books').then(() =>
-      saveFiles(entries, fields)
-    )
+  const $ = await request(`${baseUrl}/index.html`)
+  // cheerio (https://cheerio.js.org/) uses the same api as jQuery (http://jquery.com/)
+  const documents = await parseDocuments($)
+
+  // here we use the saveBills function even if what we fetch are not bills, but this is the most
+  // common case in connectors
+  await saveBills(documents, fields.folderPath, {
+    // this is a bank identifier which will be used to link bills to bank operations. These
+    // identifiers should be at least a word found in the title of a bank operation related to this
+    // bill. It is not case sensitive.
+    identifiers: ['books']
   })
 }
 
-// The goal of this function is to parse a html page wrapped by a cheerio instance // and return an array of js objects which will be saved to the cozy by addData (https://github.com/cozy/cozy-konnector-libs/blob/master/docs/api.md#module_addData)
-// and saveFiles (https://github.com/cozy/cozy-konnector-libs/blob/master/docs/api.md#savefiles)
-function parseArticle($, article) {
-  const $article = $(article)
-  const title = $article.find('h3 a').attr('title')
-  return {
-    title,
-    price: normalizePrice($article.find('.price_color').text()),
-    url: `${baseUrl}/${$article.find('h3 a').attr('href')}`,
-    // when it finds a fileurl attribute, saveFiles will save this file to the cozy with a filename
-    // name
-    fileurl: `${baseUrl}/${$article.find('img').attr('src')}`,
-    filename: `${title}.jpg`
-  }
+// this shows authentication using the [signin function](https://github.com/konnectors/libs/blob/master/packages/cozy-konnector-libs/docs/api.md#module_signin)
+// even if this in another domain here, but it works as an example
+function authenticate(username, password) {
+  return signin({
+    url: `http://quotes.toscrape.com/login`,
+    formSelector: 'form',
+    formData: { username, password },
+    // the validate function will check if
+    validate: (statusCode, $) => {
+      // The login in toscrape.com always works excepted when no password is set
+      if ($(`a[href='/logout']`).length === 1) {
+        return true
+      } else {
+        // cozy-konnector-libs has its own logging function which format these logs with colors in
+        // standalone and dev mode and as JSON in production mode
+        log('error', $('.error').text())
+        return false
+      }
+    }
+  })
+}
+
+// The goal of this function is to parse a html page wrapped by a cheerio instance
+// and return an array of js objects which will be saved to the cozy by saveBills (https://github.com/cozy/cozy-konnector-libs/blob/master/docs/api.md#savebills)
+function parseDocuments($) {
+  // you can find documentation about the scrape function here :
+  // https://github.com/konnectors/libs/blob/master/packages/cozy-konnector-libs/docs/api.md#scrape
+  const docs = scrape(
+    $,
+    {
+      title: {
+        sel: 'h3 a',
+        attr: 'title'
+      },
+      amount: {
+        sel: '.price_color',
+        parse: normalizePrice
+      },
+      url: {
+        sel: 'h3 a',
+        attr: 'title',
+        parse: url => `${baseUrl}/${url}`
+      },
+      fileurl: {
+        sel: 'img',
+        attr: 'src',
+        parse: src => `${baseUrl}/${src}`
+      },
+      filename: {
+        sel: 'h3 a',
+        attr: 'title',
+        parse: title => `${title}.jpg`
+      }
+    },
+    'article'
+  )
+  return docs.map(doc => ({
+    ...doc,
+    // the saveBills function needs a date field
+    // even if it is a little artificial here (these are not real bills)
+    date: new Date(),
+    currency: '€',
+    vendor: 'template',
+    metadata: {
+      // it can be interesting that we add the date of import. This is not mandatory but may be
+      // usefull for debugging or data migration
+      importDate: new Date(),
+      // document version, usefull for migration after change of document structure
+      version: 1
+    }
+  }))
 }
 
 // convert a price string to a float


### PR DESCRIPTION
- async/await is used to make async code more readable than promises
- the signin function is used which handles a lot of csrf token cases
- the scrape function is also used and it avoids some cheerio magic and is nicer to read
- shows some login code for quotes.toscrape.com, even if books.toscrape.com is scraped after
- saveBills is used, which is the most common case in connectors at the moment