### PR TITLE
Add 'manifest_version' to manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -84,5 +84,6 @@
         }
       }
     }
-  }
+  },
+  "manifest_version": "2"
 }


### PR DESCRIPTION
As discussed [here](https://mattermost.cozycloud.cc/test-team/pl/x1983pu4tpf6p8qa6dbezzh3hc), it seems relevant to start using a `manifest_version`, to prevent breaking changes in manifest attributes in the future.