### PR TITLE
Prevent building build branch

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
       { from: 'package.json' },
       { from: 'README.md' },
       { from: 'assets' },
+      { from: '.travis.yml' },
       { from: 'LICENSE' }
     ])
   ]


### PR DESCRIPTION
- We added a `branches: except: build` to the `.travis.yml`
- But the `.travis.yml` is not copied on build branch
- So it was useless
- Copy the `.travis.yml` file into the build branch