### PR TITLE
chore: use a team to manage codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # General code owners
-*      @doubleface @LucsT @aenario @sebn
+*      @konnectors/maintainers


### PR DESCRIPTION
fix #92
this allows members to be manage once for all inside github