### PR TITLE
Optimize konnectors icon (SVG) on build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,21 @@
 var path = require('path')
 const CopyPlugin = require('copy-webpack-plugin')
+const fs = require('fs')
+const SvgoInstance = require('svgo')
+
 const entry = require('./package.json').main
+
+const svgo = new SvgoInstance()
+
+let iconName
+try {
+  iconName = JSON.parse(fs.readFileSync('manifest.konnector', 'utf8')).icon
+  // we run optimize only on SVG
+  if (!iconName.match(/\.svg$/)) iconName = null
+} catch (e) {
+  // console.error(`Unable to read the icon path from manifest: ${e}`)
+}
+const appIconRX = iconName && new RegExp(`[^/]*/${iconName}`)
 
 module.exports = {
   entry,
@@ -15,9 +30,17 @@ module.exports = {
       { from: 'manifest.konnector' },
       { from: 'package.json' },
       { from: 'README.md' },
-      { from: 'assets' },
+      { from: 'assets', transform: optimizeSVGIcon },
       { from: '.travis.yml' },
       { from: 'LICENSE' }
     ])
   ]
+}
+
+function optimizeSVGIcon(buffer, path) {
+  if (appIconRX && path.match(appIconRX)) {
+    return svgo.optimize(buffer).then(resp => resp.data)
+  } else {
+    return buffer
+  }
 }


### PR DESCRIPTION
Optimise the icon svg via svgo on the webpack build.

The linter is not happy about the console statement but I can't have an empty catch statement so I kept the comment here.