### PR TITLE
Run travis sync before encrypting deploy key

### DIFF
--- a/bin/generate_travis_deploy_key
+++ b/bin/generate_travis_deploy_key
@@ -40,6 +40,8 @@ curl https://api.github.com/repos/konnectors/$reponame/keys -H "Authorization: t
 }
 EOF
 
+# Synchronize Travis to get latest repo
+travis sync
 # use travis to encrypt the private key as github_deploy_key.enc and remove the private key
 travis encrypt-file github_deploy_key --add --no-interactive -w /tmp/github_deploy_key -f
 git add github_deploy_key.enc


### PR DESCRIPTION
When encrypting github deploy key, the following error may occurs if the new konnector repository is not yet available in Travis:

```
$> travis encrypt-file github_deploy_key --add --no-interactive -w /tmp/github_deploy_key -f

detected repository as konnectors/debug
encrypting github_deploy_key for konnectors/debug
storing result as github_deploy_key.enc
storing secure env variables for decryption
resource not found ({"error":"Couldn't find repository"})
```

In this PR we fix this problem by running `travis sync` in `bin/generate_travis_deploy_key`.