### PR TITLE
fix: critical dependencies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,14 @@ module.exports = {
       { from: '.travis.yml' },
       { from: 'LICENSE' }
     ])
-  ]
+  ],
+  module: {
+    // to ignore the warnings like :
+    // WARNING in ../libs/node_modules/bindings/bindings.js 76:22-40
+    // Critical dependency: the request of a dependency is an expression
+    // Since we cannot change this dependency. I think it won't hide more important messages
+    exprContextCritical: false
+  }
 }
 
 function optimizeSVGIcon(buffer, path) {


### PR DESCRIPTION
Here is a change to the template which will hide the warning messages for which we cannot do anything like : 

WARNING in ../libs/node_modules/bindings/bindings.js 76:22-40
Critical dependency: the request of a dependency is an expression