### PR TITLE
Update Husky config

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
   "eslintIgnore": [
     "build"
   ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn lint"
+    }
+  },
   "scripts": {
     "start": "node ./src/index.js",
     "dev": "cozy-run-dev",
@@ -27,7 +32,6 @@
     "check": "konitor check .",
     "clean": "rm -rf ./data",
     "build": "webpack",
-    "precommit": "yarn lint",
     "lint": "eslint --fix .",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/konnectors/cozy-konnector-template.git}",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})",


### PR DESCRIPTION
Move hooks config from "scripts" field to "husky" field.

Setting pre-commit script in package.json is going to be be deprecated.

https://github.com/typicode/husky#upgrading-from-014
https://github.com/typicode/husky/blob/master/CHANGELOG.md#100