### PR TITLE
fix: Use konnector-dev and konnector-standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "scripts": {
     "start": "node ./src/index.js",
-    "dev": "cozy-run-dev",
-    "standalone": "cozy-run-standalone",
+    "dev": "cozy-konnector-dev",
+    "standalone": "cozy-konnector-standalone",
     "pretest": "npm run clean",
     "test": "konitor testit .",
     "check": "konitor check .",


### PR DESCRIPTION
Since run-dev has been introduced, we need to use konnector-dev to read `konnector-dev-config.json`.