### PR TITLE
feat: add access to the connector manifest via webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,13 @@
 var path = require('path')
 const CopyPlugin = require('copy-webpack-plugin')
+const webpack = require('webpack')
 const fs = require('fs')
 const SvgoInstance = require('svgo')
 
 const entry = require('./package.json').main
+
+const readManifest = () =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, './manifest.konnector')))
 
 const svgo = new SvgoInstance({
   plugins: [
@@ -41,7 +45,10 @@ module.exports = {
       { from: 'assets', transform: optimizeSVGIcon },
       { from: '.travis.yml' },
       { from: 'LICENSE' }
-    ])
+    ]),
+    new webpack.DefinePlugin({
+      __WEBPACK_PROVIDED_MANIFEST__: JSON.stringify(readManifest())
+    })
   ],
   module: {
     // to ignore the warnings like :


### PR DESCRIPTION
Some webpack setup to allow [cozy-konnector-libs to get the manifest](https://github.com/konnectors/libs/pull/422)