### PR TITLE
fix: add babel configuration file

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["cozy-app", {
+      "node": true,
+      "react": false,
+      "lib": true
+    }]
+  ]
+}


### PR DESCRIPTION
This is needed since the version 1.3.0 of cozy-konnector-build
