### PR TITLE
chore: Upgrade travis to use node 16.18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '16.16.0'
+- '16.18.1'
 env:
   global:
   - MATTERMOST_CHANNEL=publication


### PR DESCRIPTION
We'll use this version in production