### PR TITLE
chore: Remove unneeded files from built asset

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,11 +39,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: 'manifest.konnector' },
-        { from: 'package.json' },
-        { from: 'README.md' },
-        { from: 'assets', transform: optimizeSVGIcon },
-        { from: '.travis.yml' },
-        { from: 'LICENSE' }
+        { from: 'assets', transform: optimizeSVGIcon }
       ]
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
Remove unused README, LICENCE and .travis.yml files from built archive

These files are unneeded and removing them make the package smaller to download and execute on servers
